### PR TITLE
Fixed "Failed to transform to CNF" with (a=>b)=>c

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,5 @@
+v1.1.4 (to be released)
+  - fixed bug on expressions like (a=>b)=>c
 v1.1.3
   - added "View" menu item with zoom/unzoom latex viewer
   - ctrl-related shortcuts will now work with cmd on osx 

--- a/touist-translator/src/cnf.ml
+++ b/touist-translator/src/cnf.ml
@@ -68,6 +68,7 @@ let rec to_cnf = function
         | CNot y -> to_cnf y
         | CAnd (x',y') -> to_cnf (COr (CNot x', CNot y'))
         | COr (x',y') -> CAnd (to_cnf (CNot x'), to_cnf (CNot y'))
+        | CImplies (x',y') -> CAnd (to_cnf x', CNot (to_cnf y'))
         | x -> failwith ("Failed to transform to CNF: " ^ (string_of_clause x))
       end
   | COr (x,y) ->


### PR DESCRIPTION
The bug was happening with
        (a => b) => c
that was expanded into
        COr(CNot (CImplies a,b), c)
but CNot has no "CImplies" in its match.

I guess we'll have the same issue with equiv and xor