### PR TITLE
By default, uses stdout and stdin with option "-" (touistc)

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,5 @@
+v1.2.0 (to be released)
+  - touistc: select stdin with "-" and default output to stdout
 v1.1.4
   - fixed bug on expressions like (a=>b)=>c
 v1.1.3


### PR DESCRIPTION
Note that the output will be, in SAT mode, comprised of
- the DIMACS in cnf form
- the table with the correspondence with the literals and numbers

Allows to use `touistc` without leaving the terminal:

```
echo 'begin formula ((p => q) and (q => r)) => r end formula' > a && ./touistc.native a -sat
```
will print directly to the terminal (although the CNF and hash table are printed one after the other)