### PR TITLE
Proposition de modification/simplification de cnf.ml

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,5 +1,7 @@
 v1.2.0 (to be released)
   - touistc: select stdin with "-" and default output to stdout
+  - touistc: fixed bugs when translating to CNF; now handles correctly
+    forms like `((p => q) and (q => r)) => r` and cleaned code.
 v1.1.4
   - fixed bug on expressions like (a=>b)=>c
 v1.1.3

--- a/touist-translator/src/cnf.ml
+++ b/touist-translator/src/cnf.ml
@@ -1,6 +1,6 @@
 (*
- * cnf.ml: processes the "semantically correct" abstract syntaxic tree (ast) given by [eval]
- *         to produce a CNF-compliant version of the abstract syntaxic tree.
+ * cnf.ml: processes the "semantically correct" abstract syntax tree (ast) given by [eval]
+ *         to produce a CNF-compliant version of the abstract syntax tree.
  *         [to_cnf] is the main function.
  *
  * Project TouIST, 2015. Easily formalize and solve real-world sized problems
@@ -41,11 +41,11 @@ let genterm () =
       literals separated by "and"; example:
           a and b and not and not d                 is a conjunction
     - AST:
-      abstract syntaxic tree; it is homogenous to Syntax.clause
+      abstract syntax tree; it is homogenous to Syntax.clause
       and is a recursive tree representing a formula, using COr, CAnd, CImplies...
-      Example: (1) has the abstract syntaxic tree (2):
+      Example: the formula (1) has the abstract syntax tree (2):
           (a or b) and not c                          (1) natural language
-          CAnd (COr (Term a, Term b),CNot (Term c))   (2) abstract syntaxic tree
+          CAnd (COr (Term a, Term b),CNot (Term c))   (2) abstract syntax tree
     - CNF:
       a Conjunctive Normal Form is an AST that has a special structure with
       is a conjunction of disjunctions of literals. For example:
@@ -53,15 +53,17 @@ let genterm () =
           (a and b) or not (c or d)                 is not a CNF form
  *)
 
-(* [is_clause] checks that the given ast is a clause. *)
+(* [is_clause] checks that the given AST is a clause. This function can only
+   be called on an AST containing COr, CAnd or CNot. No CEquiv or CImplies! *)
 let rec is_clause (ast: clause) : bool = match ast with
   | Top | Bottom | Term _ | CNot (Term _) -> true
   | CAnd _ -> false
   | COr (x,y) -> is_clause x && is_clause y
   | x -> failwith ("is_clause: unexpected value " ^ (string_of_clause x))
 
-(* [push_lit] allows to translate the disjunction `d or cnf` with `d` being the
-   literal we want to add and `cnf` the existing CNF form; for example:
+(* [push_lit] allows to translate into CNF the non-CNF disjunction `d or cnf`
+   (`d` is the literal we want to add, `cnf` is the existing CNF form).
+   For example:
           d  or  ((a or not b) and (not c))            <- is not in CNF
     <=>   push_lit (d) ((a or not b) and not c)
     <=>   (d or a or b) and (d or not c)               <- is in CNF
@@ -82,7 +84,7 @@ let rec push_lit (lit:clause) (cnf: clause) : clause = match cnf with
  * COr, CAnd and CNot; moreover, it can only be in a conjunction of clauses (see a reminder of their definition
  * below). For example (instead of CAnd, COr we use "and" and "or" and "not"):
  *     (a or not b or c) and (not a or b or d) and (d)
- * The matching abstract syntaxic tree (ast) is
+ * The matching abstract syntax tree (ast) is
  *     CAnd (COr a,(Cor (CNot b),c)), (CAnd (COr (COr (CNot a),b),d), d)
  * *)
 let rec to_cnf (ast:clause) : clause = match ast with

--- a/touist-translator/src/cnf.ml
+++ b/touist-translator/src/cnf.ml
@@ -99,12 +99,12 @@ let rec to_cnf (ast:clause) : clause = match ast with
   | CNot x -> let x = to_cnf x in
     begin
       match x with
-      | Top -> Bottom
-      | Bottom -> Top
-      | Term a -> CNot (Term a)
-      | CNot x -> x
+      | Top        -> Bottom
+      | Bottom     -> Top
+      | Term a     -> CNot (Term a)
+      | CNot x     -> x
       | CAnd (x,y) -> to_cnf (COr (CNot x, CNot y))          (* De Morgan *)
-      | COr (x,y) -> CAnd (to_cnf (CNot x), to_cnf (CNot y)) (* De Morgan *)
+      | COr (x,y)  -> CAnd (to_cnf (CNot x), to_cnf (CNot y)) (* De Morgan *)
       (* For any other forms like CImplies, CEquiv or CXor: must be  *)
       | _ -> failwith("Bug when turning to CNF: " ^ (string_of_clause (CNot x)))
     end
@@ -121,7 +121,7 @@ let rec to_cnf (ast:clause) : clause = match ast with
         let (new1, new2) = (genterm (), genterm ()) in
         CAnd (COr (new1, new2), CAnd (push_lit (CNot new1) x,
                                       push_lit (CNot new2) y))
-      end
+    end
       (* Note on `COr` and the Tseytin transform:
          When translating `x or y` into CNF and that either x or y is a
          conjunction (= isn't a clause), we must avoid the 'natural' translation

--- a/touist-translator/src/cnf.ml
+++ b/touist-translator/src/cnf.ml
@@ -18,13 +18,6 @@
 open Syntax
 open Pprint
 
-(* [genterm] generates a (Term &i) with i being a self-incrementing index.
- * This function allows to speed up and simplify the translation of some
- * forms of COr *)
-let dummy_term_count = ref 0
-let genterm () =
-  incr dummy_term_count; Term ("&" ^ (string_of_int !dummy_term_count), None)
-
 (*  Vocabulary:
     - Literal:
       a possibly negated proposition; we denote them as a, b... and
@@ -79,6 +72,15 @@ let rec push_lit (lit:clause) (cnf: clause) : clause = match cnf with
   | CAnd (x,y)    -> CAnd (push_lit lit x, push_lit lit y)
   | COr (x,y)     -> COr (lit, COr (x,y))
   | x -> failwith ("Cnf.push_lit: unexpected " ^ (string_of_clause x))
+
+
+(* [genterm] generates a (Term &i) with i being a self-incrementing index.
+ * This function allows to speed up and simplify the translation of some
+ * forms of COr.
+ * NOTE: OCaml's functions can't have 0 param: we use the unit `()`. *)
+let dummy_term_count = ref 0
+let genterm () =
+  incr dummy_term_count; Term ("&" ^ (string_of_int !dummy_term_count), None)
 
 (* [to_cnf] translates the syntaxic tree made of COr, CAnd, CImplies, CEquiv...
  * COr, CAnd and CNot; moreover, it can only be in a conjunction of clauses

--- a/touist-translator/src/cnf.ml
+++ b/touist-translator/src/cnf.ml
@@ -78,7 +78,7 @@ let rec push_lit (lit:clause) (cnf: clause) : clause = match cnf with
   | CNot (Term x) -> COr (lit, CNot (Term x))
   | CAnd (x,y)    -> CAnd (push_lit lit x, push_lit lit y)
   | COr (x,y)     -> COr (lit, COr (x,y))
-  | x -> failwith ("push_lit: unexpected value " ^ (string_of_clause x))
+  | x -> failwith ("Cnf.push_lit: unexpected " ^ (string_of_clause x))
 
 (* [to_cnf] translates the syntaxic tree made of COr, CAnd, CImplies, CEquiv...
  * COr, CAnd and CNot; moreover, it can only be in a conjunction of clauses (see a reminder of their definition
@@ -108,7 +108,7 @@ let rec to_cnf (ast:clause) : clause = match ast with
       | CAnd (x,y) -> to_cnf (COr (CNot x, CNot y))          (* De Morgan *)
       | COr (x,y)  -> CAnd (to_cnf (CNot x), to_cnf (CNot y)) (* De Morgan *)
       (* For any other forms like CImplies, CEquiv or CXor: must be  *)
-      | _ -> failwith("Bug when turning to CNF: " ^ (string_of_clause (CNot x)))
+      | _ -> failwith("Cnf.CNot failed on: " ^ (string_of_clause (CNot x)))
     end
   | COr (x,y) -> let (x,y) = (to_cnf x, to_cnf y) in
     begin
@@ -139,7 +139,7 @@ let rec to_cnf (ast:clause) : clause = match ast with
   | CImplies (x,y) -> to_cnf (COr (CNot x, y))
   | CEquiv (x,y) -> to_cnf (CAnd (CImplies (x,y), CImplies (y,x)))
   | CXor (x,y) -> to_cnf (CAnd (COr (x,y), COr (CNot x, CNot y)))
-  | _ -> failwith "Failed to transform to CNF"
+  | _ -> failwith("Cnf.to_cnf failed on: " ^ (string_of_clause ast))
 
 (*
 print_endline ((string_of_clause x) ^ " --- " ^ (string_of_clause x));

--- a/touist-translator/src/cnf.ml
+++ b/touist-translator/src/cnf.ml
@@ -99,17 +99,17 @@ let rec to_cnf (ast:clause) : clause = match ast with
       | Bottom,_|_,Bottom -> Bottom
       | x,y               -> CAnd (x,y)
     end
-  | CNot x -> let x = to_cnf x in
+  | CNot x ->
     begin
       match x with
       | Top        -> Bottom
       | Bottom     -> Top
       | Term a     -> CNot (Term a)
-      | CNot x     -> x
+      | CNot x     -> to_cnf x
       | CAnd (x,y) -> to_cnf (COr (CNot x, CNot y))          (* De Morgan *)
       | COr (x,y)  -> CAnd (to_cnf (CNot x), to_cnf (CNot y)) (* De Morgan *)
-      (* For any other forms like CImplies, CEquiv or CXor: must be  *)
-      | _ -> failwith("Cnf.CNot failed on: " ^ (string_of_clause (CNot x)))
+      (* For any other forms like CImplies, CEquiv or CXor: must re-run to_cnf *)
+      | _ -> to_cnf (CNot (to_cnf x))
     end
   | COr (x,y) -> let (x,y) = (to_cnf x, to_cnf y) in
     begin

--- a/touist-translator/src/cnf.ml
+++ b/touist-translator/src/cnf.ml
@@ -105,8 +105,8 @@ let rec to_cnf (ast:clause) : clause = match ast with
       | CNot x -> x
       | CAnd (x,y) -> to_cnf (COr (CNot x, CNot y))          (* De Morgan *)
       | COr (x,y) -> CAnd (to_cnf (CNot x), to_cnf (CNot y)) (* De Morgan *)
-      (* At this point, x has not been "translated" enough to be matched by CNot *)
-      | x -> to_cnf (CNot x)
+      (* For any other forms like CImplies, CEquiv or CXor: must be  *)
+      | _ -> failwith("Bug when turning to CNF: " ^ (string_of_clause (CNot x)))
     end
   | COr (x,y) -> let (x,y) = (to_cnf x, to_cnf y) in
     begin

--- a/touist-translator/src/cnf.ml
+++ b/touist-translator/src/cnf.ml
@@ -81,8 +81,9 @@ let rec push_lit (lit:clause) (cnf: clause) : clause = match cnf with
   | x -> failwith ("Cnf.push_lit: unexpected " ^ (string_of_clause x))
 
 (* [to_cnf] translates the syntaxic tree made of COr, CAnd, CImplies, CEquiv...
- * COr, CAnd and CNot; moreover, it can only be in a conjunction of clauses (see a reminder of their definition
- * below). For example (instead of CAnd, COr we use "and" and "or" and "not"):
+ * COr, CAnd and CNot; moreover, it can only be in a conjunction of clauses
+ * (see a reminder of their definition above).
+ * For example (instead of CAnd, COr we use "and" and "or" and "not"):
  *     (a or not b or c) and (not a or b or d) and (d)
  * The matching abstract syntax tree (ast) is
  *     CAnd (COr a,(Cor (CNot b),c)), (CAnd (COr (COr (CNot a),b),d), d)
@@ -140,7 +141,3 @@ let rec to_cnf (ast:clause) : clause = match ast with
   | CEquiv (x,y) -> to_cnf (CAnd (CImplies (x,y), CImplies (y,x)))
   | CXor (x,y) -> to_cnf (CAnd (COr (x,y), COr (CNot x, CNot y)))
   | _ -> failwith("Cnf.to_cnf failed on: " ^ (string_of_clause ast))
-
-(*
-print_endline ((string_of_clause x) ^ " --- " ^ (string_of_clause x));
-*)

--- a/touist-translator/src/cnf.ml
+++ b/touist-translator/src/cnf.ml
@@ -1,5 +1,5 @@
 (*
- * cnf.ml: processes the "semantically correct" abstract syntaxic tree given by [eval]
+ * cnf.ml: processes the "semantically correct" abstract syntaxic tree (ast) given by [eval]
  *         to produce a CNF-compliant version of the abstract syntaxic tree.
  *         [to_cnf] is the main function.
  *
@@ -9,8 +9,8 @@
  * https://github.com/touist/touist
  *
  * Copyright Institut de Recherche en Informatique de Toulouse, France
- * This program and the accompanying materials are made available 
- * under the terms of the GNU Lesser General Public License (LGPL) 
+ * This program and the accompanying materials are made available
+ * under the terms of the GNU Lesser General Public License (LGPL)
  * version 2.1 which accompanies this distribution, and is available at
  * http://www.gnu.org/licenses/lgpl-2.1.html
  *)
@@ -18,86 +18,127 @@
 open Syntax
 open Pprint
 
+(* [genterm] generates a (Term &i) with i being a self-incrementing index.
+ * This function allows to speed up and simplify the translation of some
+ * forms of COr *)
 let dummy_term_count = ref 0
 let genterm () =
   incr dummy_term_count; Term ("&" ^ (string_of_int !dummy_term_count), None)
 
-let rec is_clause = function
+(*  Vocabulary:
+    - Literal:
+      a possibly negated proposition; we denote them as a, b... and
+      their type is homogenous to Term _ or CNot(Term _) or Top or Bottom. Exples:
+          a                                         is a literal
+          not b                                     is a literal
+    - Clause:
+      a disjunction (= separated by "or") of possibly negated literals.
+      Example of clause:
+          a or not b or c or d                      is a clause
+      WARNING: Syntax.clause isn't actually a clause as defined here; it can
+      hold CImplies, CEquiv, CXor. Its naming isn't really appropriate...
+    - Conjunction:
+      literals separated by "and"; example:
+          a and b and not and not d                 is a conjunction
+    - AST:
+      abstract syntaxic tree; it is homogenous to Syntax.clause
+      and is a recursive tree representing a formula, using COr, CAnd, CImplies...
+      Example: (1) has the abstract syntaxic tree (2):
+          (a or b) and not c                          (1) natural language
+          CAnd (COr (Term a, Term b),CNot (Term c))   (2) abstract syntaxic tree
+    - CNF:
+      a Conjunctive Normal Form is an AST that has a special structure with
+      is a conjunction of disjunctions of literals. For example:
+          (a or not b) and (not c and d)            is a CNF form
+          (a and b) or not (c or d)                 is not a CNF form
+ *)
+
+(* [is_clause] checks that the given ast is a clause. *)
+let rec is_clause (ast: clause) : bool = match ast with
   | Top | Bottom | Term _ | CNot (Term _) -> true
-  | CNot x -> is_conj x
   | CAnd _ -> false
   | COr (x,y) -> is_clause x && is_clause y
   | x -> failwith ("is_clause: unexpected value " ^ (string_of_clause x))
-and is_conj = function
-  | Top | Bottom | Term _ | CNot (Term _) -> true
-  | CNot x -> is_clause x
-  | COr _  -> false
-  | CAnd (x,y) -> is_conj x && is_conj y
-  | x -> failwith ("is_conj: unexpected value " ^ (string_of_clause x))
 
-let rec push_lit lit = function
+(* [push_lit] allows to translate the disjunction `d or cnf` with `d` being the
+   literal we want to add and `cnf` the existing CNF form; for example:
+          d  or  ((a or not b) and (not c))            <- is not in CNF
+    <=>   push_lit (d) ((a or not b) and not c)
+    <=>   (d or a or b) and (d or not c)               <- is in CNF
+    This function is necessary because `d or cnf` (with `cnf` an arbitrary CNF
+    form) is not a CNF form and must be modified. Conversely, the form
+          `d  and  ((a or not b) and (not c))`
+    doesn't need to be modified because it is already in CNF.  *)
+let rec push_lit (lit:clause) (cnf: clause) : clause = match cnf with
   | Top           -> Top
   | Bottom        -> lit
   | Term x        -> COr (lit, Term x)
   | CNot (Term x) -> COr (lit, CNot (Term x))
   | CAnd (x,y)    -> CAnd (push_lit lit x, push_lit lit y)
   | COr (x,y)     -> COr (lit, COr (x,y))
-  | x -> failwith ("push_lit: unexpected value " ^ (string_of_clause x)) 
+  | x -> failwith ("push_lit: unexpected value " ^ (string_of_clause x))
 
-let rec to_cnf = function
+(* [to_cnf] translates the syntaxic tree made of COr, CAnd, CImplies, CEquiv...
+ * COr, CAnd and CNot; moreover, it can only be in a conjunction of clauses (see a reminder of their definition
+ * below). For example (instead of CAnd, COr we use "and" and "or" and "not"):
+ *     (a or not b or c) and (not a or b or d) and (d)
+ * The matching abstract syntaxic tree (ast) is
+ *     CAnd (COr a,(Cor (CNot b),c)), (CAnd (COr (COr (CNot a),b),d), d)
+ * *)
+let rec to_cnf (ast:clause) : clause = match ast with
   | Top    -> Top
   | Bottom -> Bottom
-  | Term x -> Term x
-  | CAnd (Top,x) | CAnd (x,Top) -> to_cnf x
-  | CAnd (Bottom,_) | CAnd (_,Bottom) -> Bottom
-  | CAnd (x,y) ->
-      begin
-        let x' = to_cnf x in
-        let y' = to_cnf y in
-        match x',y' with 
-        | Top,_ -> y'
-        | _,Top -> x'
-        | _,_   -> CAnd (x',y')
+  | Term a -> Term a
+  | CAnd (x,y) -> let (x,y) = (to_cnf x, to_cnf y) in
+    begin
+      match x,y with
+      | Top,x | x,Top     -> x
+      | Bottom,_|_,Bottom -> Bottom
+      | x,y               -> CAnd (x,y)
+    end
+  | CNot x -> let x = to_cnf x in
+    begin
+      match x with
+      | Top -> Bottom
+      | Bottom -> Top
+      | Term a -> CNot (Term a)
+      | CNot x -> x
+      | CAnd (x,y) -> to_cnf (COr (CNot x, CNot y))          (* De Morgan *)
+      | COr (x,y) -> CAnd (to_cnf (CNot x), to_cnf (CNot y)) (* De Morgan *)
+      (* At this point, x has not been "translated" enough to be matched by CNot *)
+      | x -> to_cnf (CNot x)
+    end
+  | COr (x,y) -> let (x,y) = (to_cnf x, to_cnf y) in
+    begin
+      match x,y with
+      | Bottom, z | z, Bottom   -> z
+      | Top, _ | _, Top         -> Top
+      | Term a, z | z, Term a   -> push_lit (Term a) z
+      | CNot (Term a),z | z,CNot (Term a) -> push_lit (CNot (Term a)) z
+      | x,y when is_clause x && is_clause y -> COr (x, y)
+      | x,y -> (* At this point, either x or y is a conjunction
+                  => Tseytin transform (see explanations below) *)
+        let (new1, new2) = (genterm (), genterm ()) in
+        CAnd (COr (new1, new2), CAnd (push_lit (CNot new1) x,
+                                      push_lit (CNot new2) y))
       end
-  | CNot x ->
-      begin
-        match x with
-        | Top -> Bottom
-        | Bottom -> Top
-        | Term a -> CNot (Term a)
-        | CNot y -> to_cnf y
-        | CAnd (x',y') -> to_cnf (COr (CNot x', CNot y'))
-        | COr (x',y') -> CAnd (to_cnf (CNot x'), to_cnf (CNot y'))
-        | CImplies (x',y') -> CAnd (to_cnf x', CNot (to_cnf y'))
-        | x -> failwith ("Failed to transform to CNF: " ^ (string_of_clause x))
-      end
-  | COr (x,y) ->
-      begin
-        match x,y with
-        | Bottom, x' | x', Bottom -> to_cnf x'
-        | Top, _ | _, Top -> Top
-        | Term a, Term b               -> COr (Term a, Term b)
-        | CNot (Term a), Term b        -> COr (CNot (Term a), Term b)
-        | CNot (Term a), CNot (Term b) -> COr (CNot (Term a), CNot (Term b))
-        | Term a, CNot (Term b)        -> COr (Term a, CNot (Term b))
-        | Term a, y' | y', Term a -> push_lit (Term a) (to_cnf y')
-        | CNot (Term a), y' | y', CNot (Term a) -> push_lit (CNot (Term a)) (to_cnf y')
-        | _,_ ->
-            let x' = to_cnf x in
-            let y' = to_cnf y in
-            match x',y' with
-            | Bottom,_ -> y'
-            | _,Bottom -> x'
-            | _,_ ->
-                if is_clause x && is_clause y then
-                  COr (to_cnf x, to_cnf y)
-                else
-                  let (new1, new2) = (genterm (), genterm ()) in
-                  CAnd (COr (new1, new2), CAnd (push_lit (CNot new1) (to_cnf x),
-                                                push_lit (CNot new2) (to_cnf y)))
-      end
+      (* Note on `COr` and the Tseytin transform:
+         When translating `x or y` into CNF and that either x or y is a
+         conjunction (= isn't a clause), we must avoid the 'natural' translation
+         that should occur when translating (1) into (2): (2) would have an
+         exponential number of clauses. Instead, we use arbitrary variables
+         created by [genterm], denoted by &1, &2... and use the Tseytin
+         transform (3) which yields a linear number of clauses.
+              (x1 and y1)  or  (x2 and y2)                                (1)
+              (x1 or x2) and (x1 or y2) and (y1 or x2) or (etc...)        (2)
+              (&1 or &2) and (not &1 or x1) and (not &1 or y1)            (3)
+                        and (not &2 or x2) and (not &2 or y2)
+      *)
   | CImplies (x,y) -> to_cnf (COr (CNot x, y))
   | CEquiv (x,y) -> to_cnf (CAnd (CImplies (x,y), CImplies (y,x)))
   | CXor (x,y) -> to_cnf (CAnd (COr (x,y), COr (CNot x, CNot y)))
   | _ -> failwith "Failed to transform to CNF"
 
+(*
+print_endline ((string_of_clause x) ^ " --- " ^ (string_of_clause x));
+*)


### PR DESCRIPTION
- is_clause is no longer checking when negation + conjunction is found.
  The formula should be presumed as "already simplified" and thus
  no "not (a and b)" should be found when trying to use is_clause
- is_conj removed
- simplified COr. When entering inside COr, the to_cnf on each
  x and y has already been made: only CNot, COr and CAnd are left.
  Two simple cases when it is not one of the 4 literal cases:
     1. x and y are clauses, this is the easy case -> x or y
     2. x or y is not a clause (a conjunction exists) and we must
        "distribute" using Tseytin transform

This PR is a response to the PR #177 and #178