### PR TITLE
Fix to_cnf inner/outer bug

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -6,6 +6,10 @@ v1.3.0 (to be released)
   - added <=> symbol that had been forgotten at some point
   - fix touist hanging on "solve" on some unsatisfiable formulas
   - fix subset(.,.) construct not displayed in latex display
+  - touistc: fixed bug with `not((p => p) => (q => q))` that should be
+    unsat; it was related to CNF expansion happening in inner -> outer
+    instead of outer -> inner
+  - touistc: added --debug-cnf option
 v1.2.0
   - touistc: select stdin with "-" and default output to stdout
   - touistc: fixed bugs when translating to CNF; now handles correctly

--- a/touist-translator/src/pprint.ml
+++ b/touist-translator/src/pprint.ml
@@ -5,7 +5,7 @@ let rec string_of_exp = function
   | Float  x -> string_of_float x
   | Bool   x -> string_of_bool x
   | Var (x,None)   -> x
-  | Var (x,Some y) -> x ^ "(" ^ (string_of_exp_list ", " y) ^ ")" 
+  | Var (x,Some y) -> x ^ "(" ^ (string_of_exp_list ", " y) ^ ")"
   | Clause x -> string_of_clause x
   | Set    x -> string_of_set x
   | Set_decl x -> "<set-decl>"
@@ -63,12 +63,12 @@ and string_of_clause = function
   | CVar (x,Some y) -> x ^ "(" ^ (string_of_exp_list ", " y) ^ ")"
   | Term (x,None)   -> x
   | Term (x,Some y) -> x ^ "(" ^ (string_of_exp_list ", " y) ^ ")"
-  | CNot x -> "not " ^ (string_of_clause x)
+  | CNot x -> "(not " ^ (string_of_clause x) ^ ")"
   | CAnd     (x,y) -> "(" ^ (string_of_clause x) ^ " and " ^ (string_of_clause y) ^ ")"
   | COr      (x,y) -> "(" ^ (string_of_clause x) ^ " or "  ^ (string_of_clause y) ^ ")"
-  | CXor     (x,y) -> (string_of_clause x) ^ " xor " ^ (string_of_clause y)
-  | CImplies (x,y) -> (string_of_clause x) ^ " => "  ^ (string_of_clause y)
-  | CEquiv   (x,y) -> (string_of_clause x) ^ " <=> " ^ (string_of_clause y)
+  | CXor     (x,y) -> "(" ^ (string_of_clause x) ^ " xor " ^ (string_of_clause y) ^ ")"
+  | CImplies (x,y) -> "(" ^ (string_of_clause x) ^ " => "  ^ (string_of_clause y) ^ ")"
+  | CEquiv   (x,y) -> "(" ^ (string_of_clause x) ^ " <=> " ^ (string_of_clause y) ^ ")"
   | Bigand (x,y,None,z) ->
       "bigand " ^ (String.concat "," x)
        ^ " in " ^ (string_of_exp_list "," y)
@@ -122,5 +122,3 @@ and string_of_floatset s =
 
 and string_of_strset s =
   "[" ^ (String.concat ", " (StringSet.elements s)) ^ "]"
-
-

--- a/touist-translator/src/touistc.ml
+++ b/touist-translator/src/touistc.ml
@@ -70,6 +70,7 @@ let use_stdin = ref false
 let output = ref stdout
 let output_table = ref stdout
 let input = ref stdin
+let debug_cnf = ref false
 
 let print_position outx lexbuf =
   let pos = lexbuf.lex_curr_p in
@@ -179,7 +180,7 @@ let translateToSATDIMACS (infile:in_channel) (outfile:out_channel) (tablefile:ou
   and buffer = ref ErrorReporting.Zero in
   let ast = invoke_parser text (lexer buffer) buffer in
     let exp = evaluate ast in
-      let c,t = Cnf.to_cnf exp |> Dimacs.to_dimacs in
+      let c,t = Cnf.transform_to_cnf exp !debug_cnf |> Dimacs.to_dimacs in
         Printf.fprintf outfile "%s" c;
         Printf.fprintf tablefile "%s" (Dimacs.string_of_table t)
 
@@ -214,7 +215,8 @@ let () =
     ));
     ("-d", Arg.Set debug, "Prints info for debugging syntax errors");
     ("--version", Arg.Set version_asked, "Display version number");
-    ("-", Arg.Set use_stdin,"reads from stdin instead of file")
+    ("-", Arg.Set use_stdin,"reads from stdin instead of file");
+    ("--debug-cnf", Arg.Set debug_cnf,"Print step by step CNF transformation");
   ]
   in
   let usage = "TouistL compiles files from the TouIST Language \


### PR DESCRIPTION
```
begin formula 
not((p => p) => (q => q)) 
end formula
```
was satisfiable instead but should be unsat.