### PR TITLE
Correction du "ç" de Français sous windows. (MenuBar)

### DIFF
--- a/touist-gui/src/gui/menu/EditionMenuBar.java
+++ b/touist-gui/src/gui/menu/EditionMenuBar.java
@@ -79,7 +79,7 @@ public class EditionMenuBar extends JMenuBar {
         
         
         jMenuItemEnglish = new JMenuItem("English");
-        jMenuItemFrench = new JMenuItem("Français");
+        jMenuItemFrench = new JMenuItem("Fran\u00E7ais");
         
         jMenuItemSaveFile = new JMenuItem();
         jMenuItemSaveFile.setAccelerator(KeyStroke.getKeyStroke(java.awt.event.KeyEvent.VK_S, java.awt.Event.META_MASK));

--- a/touist-gui/src/gui/menu/EditionMenuBar.java
+++ b/touist-gui/src/gui/menu/EditionMenuBar.java
@@ -79,7 +79,7 @@ public class EditionMenuBar extends JMenuBar {
         
         
         jMenuItemEnglish = new JMenuItem("English");
-        jMenuItemFrench = new JMenuItem("FranÃ§ais");
+        jMenuItemFrench = new JMenuItem("Français");
         
         jMenuItemSaveFile = new JMenuItem();
         jMenuItemSaveFile.setAccelerator(KeyStroke.getKeyStroke(java.awt.event.KeyEvent.VK_S, java.awt.Event.META_MASK));


### PR DESCRIPTION
Suite à un problème d'encodage, du fichier EditionMenuBar.java , le ç de français dans le MenuBar ne s'affichait pas correctement.