### PR TITLE
Merged exp and clause types for removing redundant code

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,10 +1,12 @@
+v1.4.0
+  - touistc:
+    - (internal) merged exp and clause types for less code redundancy
 v1.3.1
   - touistc:
     - fixed `a (b)` recognized as `a(b)` instead of `a and b`
     - added --debug-formula-expansion which prints the "expanded" version
       of bigand, bigor, exact and numerical expressions; helps for debugging
       complex formulas!
-	- (internal) merged exp and clause types for less code redundancy
   - gui:
     - select the system language automatically
 	- fix "export" button not working

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -4,6 +4,7 @@ v1.3.1
     - added --debug-formula-expansion which prints the "expanded" version
       of bigand, bigor, exact and numerical expressions; helps for debugging
       complex formulas!
+	- (internal) merged exp and clause types for less code redundancy
   - gui:
     - select the system language automatically
 	- fix "export" button not working

--- a/touist-translator/src/dimacs.ml
+++ b/touist-translator/src/dimacs.ml
@@ -26,9 +26,9 @@ let to_dimacs prop =
     | Bottom -> failwith "Clause is alway false"
     | Term (x, None)        -> acc ^ string_of_int (gensym x)
     | Term (x, _)           -> failwith ("unevaluated term: " ^ x)
-    | CNot (Term (x, None)) -> acc ^ string_of_int (- (gensym x))
-    | CAnd (x, y) -> incr nbclause; (go acc x) ^ " 0\n" ^ (go acc y)
-    | COr  (x, y) -> (go acc x) ^ " " ^ (go acc y)
+    | Not (Term (x, None)) -> acc ^ string_of_int (- (gensym x))
+    | And (x, y) -> incr nbclause; (go acc x) ^ " 0\n" ^ (go acc y)
+    | Or  (x, y) -> (go acc x) ^ " " ^ (go acc y)
     | _ -> failwith "non CNF clause"
   and gensym x =
     try Hashtbl.find table x
@@ -53,9 +53,9 @@ let to_text prop =
     | Bottom -> (*failwith "Clause is alway false"*) "VBot"
     | Term (x, None)        -> acc ^ x
     | Term (x, _)           -> failwith ("unevaluated term: " ^ x)
-    | CNot (Term (x, None)) -> acc ^ "-" ^ x
-    | CAnd (x, y) -> incr nbclause; (go acc x) ^ " \n" ^ (go acc y)
-    | COr  (x, y) -> (go acc x) ^ " v " ^ (go acc y)
+    | Not (Term (x, None)) -> acc ^ "-" ^ x
+    | And (x, y) -> incr nbclause; (go acc x) ^ " \n" ^ (go acc y)
+    | Or  (x, y) -> (go acc x) ^ " v " ^ (go acc y)
     | _ -> failwith "non CNF clause"
   in
   let str = (go "" prop) ^ " 0\n" in

--- a/touist-translator/src/parser.mly
+++ b/touist-translator/src/parser.mly
@@ -135,7 +135,7 @@ var_decl:
   | VAR { ($1, None) }
   | v=VARTUPLE (*LPAREN*) l=separated_nonempty_list(COMMA, exp) RPAREN { (v, Some l) }
   | v=VARTUPLE (*LPAREN*) l=separated_nonempty_list(COMMA, TERM) RPAREN
-    { (v, Some (List.map (fun e -> Clause (Term (e,None))) l)) }
+    { (v, Some (List.map (fun e -> Term (e,None)) l)) }
 
 affect:
   | var_decl AFFECT exp { Affect ($1, $3) }
@@ -197,8 +197,8 @@ exp:
 
 clause:
   | LPAREN clause RPAREN { $2 }
-  | INT   { CInt   $1 }
-  | FLOAT { CFloat $1 }
+  | INT   { Int   $1 }
+  | FLOAT { Float $1 }
 
   (* SUB clause makes it really "hard" to solve. Just one example;
      On the first line, the actual list of tokens. On the two following
@@ -207,29 +207,29 @@ clause:
       clause -> clause1 SUB clause2        => ((clause1 SUB clause2) XOR clause3)
       clause ->         SUB clause2        => (clause 1)((SUB clause2) XOR clause3)
    *)
-  | SUB clause { CNeg $2 } %prec high_precedence
-  | clause ADD      clause { CAdd              ($1, $3) }
-  | clause SUB      clause { CSub              ($1, $3) }
-  | clause MUL      clause { CMul              ($1, $3) }
-  | clause DIV      clause { CDiv              ($1, $3) }
-  | clause EQUAL    clause { CEqual            ($1, $3) }
-  | clause NOTEQUAL clause { CNot_equal        ($1, $3) }
-  | clause LT       clause { CLesser_than      ($1, $3) }
-  | clause LE       clause { CLesser_or_equal  ($1, $3) }
-  | clause GT       clause { CGreater_than     ($1, $3) }
-  | clause GE       clause { CGreater_or_equal ($1, $3) }
-  | var_decl { CVar $1 }
+  | SUB clause { Neg $2 } %prec high_precedence
+  | clause ADD      clause { Add              ($1, $3) }
+  | clause SUB      clause { Sub              ($1, $3) }
+  | clause MUL      clause { Mul              ($1, $3) }
+  | clause DIV      clause { Div              ($1, $3) }
+  | clause EQUAL    clause { Equal            ($1, $3) }
+  | clause NOTEQUAL clause { Not_equal        ($1, $3) }
+  | clause LT       clause { Lesser_than      ($1, $3) }
+  | clause LE       clause { Lesser_or_equal  ($1, $3) }
+  | clause GT       clause { Greater_than     ($1, $3) }
+  | clause GE       clause { Greater_or_equal ($1, $3) }
+  | var_decl { Var $1 }
   | TOP    { Top    }
   | BOTTOM { Bottom }
   | TERM   { Term ($1, None) }
   | t=TUPLE (*LPAREN*) l=separated_nonempty_list(COMMA, term_or_exp) RPAREN
       { Term (t, Some l) }
-  | NOT clause { CNot $2 }
-  | clause AND     clause { CAnd     ($1, $3) }
-  | clause OR      clause { COr      ($1, $3) }
-  | clause XOR     clause { CXor     ($1, $3) }
-  | clause IMPLIES clause { CImplies ($1, $3) }
-  | clause EQUIV   clause { CEquiv   ($1, $3) }
+  | NOT clause { Not $2 }
+  | clause AND     clause { And     ($1, $3) }
+  | clause OR      clause { Or      ($1, $3) }
+  | clause XOR     clause { Xor     ($1, $3) }
+  | clause IMPLIES clause { Implies ($1, $3) }
+  | clause EQUIV   clause { Equiv   ($1, $3) }
   | EXACT (*LPAREN*) x=exp COMMA y=exp RPAREN { Exact   (x, y) }
   | ATLEAST (*LPAREN*) x=exp COMMA y=exp RPAREN { Atleast (x, y) }
   | ATMOST (*LPAREN*) x=exp COMMA y=exp RPAREN { Atmost  (x, y) }
@@ -241,18 +241,18 @@ clause:
   { Bigor ($2, $4, None, $6) }
   | BIGOR separated_nonempty_list(COMMA,VAR) IN separated_nonempty_list(COMMA,exp) WHEN exp COLON clause END
   { Bigor ($2, $4, Some $6, $8) }
-  | IF exp THEN clause ELSE clause END { CIf ($2, $4, $6) }
+  | IF exp THEN clause ELSE clause END { If ($2, $4, $6) }
 
 (* Warning: the two rules
      var_decl -> TERM
      exp -> var_decl
    are doing the same thing as term_or_exp *)
 term_or_exp:
-  | TERM { Clause (Term ($1,None)) }
+  | TERM { Term ($1,None) }
   | exp { $1 }
 
 set_decl:
   | LBRACK RBRACK { [] }
   | LBRACK separated_nonempty_list(COMMA, exp) RBRACK { $2 }
   | LBRACK separated_nonempty_list(COMMA, TERM) RBRACK
-  { List.map (fun x -> Clause (Term (x,None))) $2 }
+  { List.map (fun x -> Term (x,None)) $2 }

--- a/touist-translator/src/pprint.ml
+++ b/touist-translator/src/pprint.ml
@@ -6,7 +6,6 @@ let rec string_of_exp = function
   | Bool   x -> string_of_bool x
   | Var (x,None)   -> x
   | Var (x,Some y) -> x ^ "(" ^ (string_of_exp_list ", " y) ^ ")"
-  | Clause x -> string_of_clause x
   | Set    x -> string_of_set x
   | Set_decl x -> "<set-decl>"
   | Neg x     -> "(- " ^ (string_of_exp x) ^ ")"
@@ -43,59 +42,28 @@ let rec string_of_exp = function
       ^ " then\n" ^ (string_of_exp y)
       ^ "\nelse\n" ^ (string_of_exp z)
       ^ "\nend\n"
-and string_of_clause = function
-  | CInt x -> string_of_int x
-  | CFloat x -> string_of_float x
-  | CNeg x -> "(-" ^ (string_of_clause x) ^ ")"
-  | CAdd (x,y) -> "(" ^ (string_of_clause x) ^ " + " ^ (string_of_clause y) ^ ")"
-  | CSub (x,y) -> "(" ^ (string_of_clause x) ^ " - " ^ (string_of_clause y) ^ ")"
-  | CMul (x,y) -> "(" ^ (string_of_clause x) ^ " * " ^ (string_of_clause y) ^ ")"
-  | CDiv (x,y) -> "(" ^ (string_of_clause x) ^ " / " ^ (string_of_clause y) ^ ")"
-  | CEqual            (x,y) -> "(" ^ (string_of_clause x) ^ " == " ^ (string_of_clause y) ^ ")"
-  | CNot_equal        (x,y) -> "(" ^ (string_of_clause x) ^ " != " ^ (string_of_clause y) ^ ")"
-  | CLesser_than      (x,y) -> "(" ^ (string_of_clause x) ^ " < "  ^ (string_of_clause y) ^ ")"
-  | CLesser_or_equal  (x,y) -> "(" ^ (string_of_clause x) ^ " <= " ^ (string_of_clause y) ^ ")"
-  | CGreater_than     (x,y) -> "(" ^ (string_of_clause x) ^ " > "  ^ (string_of_clause y) ^ ")"
-  | CGreater_or_equal (x,y) -> "(" ^ (string_of_clause x) ^ " >= " ^ (string_of_clause y) ^ ")"
-  | Top    -> "top"
-  | Bottom -> "bot"
-  | CVar (x,None)   -> x
-  | CVar (x,Some y) -> x ^ "(" ^ (string_of_exp_list ", " y) ^ ")"
-  | Term (x,None)   -> x
-  | Term (x,Some y) -> x ^ "(" ^ (string_of_exp_list ", " y) ^ ")"
-  | CNot x -> "(not " ^ (string_of_clause x) ^ ")"
-  | CAnd     (x,y) -> "(" ^ (string_of_clause x) ^ " and " ^ (string_of_clause y) ^ ")"
-  | COr      (x,y) -> "(" ^ (string_of_clause x) ^ " or "  ^ (string_of_clause y) ^ ")"
-  | CXor     (x,y) -> "(" ^ (string_of_clause x) ^ " xor " ^ (string_of_clause y) ^ ")"
-  | CImplies (x,y) -> "(" ^ (string_of_clause x) ^ " => "  ^ (string_of_clause y) ^ ")"
-  | CEquiv   (x,y) -> "(" ^ (string_of_clause x) ^ " <=> " ^ (string_of_clause y) ^ ")"
   | Bigand (x,y,None,z) ->
       "bigand " ^ (String.concat "," x)
        ^ " in " ^ (string_of_exp_list "," y)
-       ^ ":\n"  ^ (string_of_clause z)
+       ^ ":\n"  ^ (string_of_exp z)
        ^ "\nend\n"
   | Bigand (x,y,Some b,z) ->
       "bigand " ^ (String.concat "," x)
        ^ " in "   ^ (string_of_exp_list "," y)
        ^ " when " ^ (string_of_exp b)
-       ^ ":\n"    ^ (string_of_clause z)
+       ^ ":\n"    ^ (string_of_exp z)
        ^ "\nend\n"
   | Bigor (x,y,None,z) ->
       "bigor " ^ (String.concat "," x)
        ^ " in " ^ (string_of_exp_list "," y)
-       ^ ":\n"  ^ (string_of_clause z)
+       ^ ":\n"  ^ (string_of_exp z)
        ^ "\nend\n"
   | Bigor (x,y,Some b,z) ->
       "bigor " ^ (String.concat "," x)
        ^ " in "   ^ (string_of_exp_list "," y)
        ^ " when " ^ (string_of_exp b)
-       ^ ":\n"    ^ (string_of_clause z)
+       ^ ":\n"    ^ (string_of_exp z)
        ^ "\nend\n"
-  | CIf (x,y,z) ->
-      "if " ^ (string_of_exp x)
-      ^ " then\n" ^ (string_of_clause y)
-      ^ "\nelse\n" ^ (string_of_clause z)
-      ^ "\nend\n"
   | Exact (x,y) -> "exact(" ^ (string_of_exp x) ^ "," ^ (string_of_exp y) ^ ")"
   | Atmost (x,y) -> "atmost(" ^ (string_of_exp x) ^ "," ^ (string_of_exp y) ^ ")"
   | Atleast (x,y) -> "atleast(" ^ (string_of_exp x) ^ "," ^ (string_of_exp y) ^ ")"

--- a/touist-translator/src/smt.ml
+++ b/touist-translator/src/smt.ml
@@ -45,71 +45,71 @@ let to_smt2 logic formula =
 
   let rec term_expr = function
     | Term (_,None)
-    | CNeg (Term _)
-    | CAdd (Term _, Term _)
-    | CSub (Term _, Term _)
-    | CMul (Term _, Term _)
-    | CDiv (Term _, Term _) -> true
-    | CNeg x -> term_expr x
-    | CAdd (x,y)
-    | CSub (x,y)
-    | CMul (x,y)
-    | CDiv (x,y) -> term_expr x && term_expr y
+    | Neg (Term _)
+    | Add (Term _, Term _)
+    | Sub (Term _, Term _)
+    | Mul (Term _, Term _)
+    | Div (Term _, Term _) -> true
+    | Neg x -> term_expr x
+    | Add (x,y)
+    | Sub (x,y)
+    | Mul (x,y)
+    | Div (x,y) -> term_expr x && term_expr y
     | _ -> false
   in
 
   let rec gen_var typ = function
     | Term (x,None) -> add_var x typ
-    | CAdd              (Term (x,None), CInt _)
-    | CAdd              (CInt _, Term (x,None))
-    | CSub              (Term (x,None), CInt _)
-    | CSub              (CInt _, Term (x,None))
-    | CMul              (Term (x,None), CInt _)
-    | CMul              (CInt _, Term (x,None))
-    | CDiv              (Term (x,None), CInt _)
-    | CDiv              (CInt _, Term (x,None))
-    | CLesser_than      (Term (x,None), CInt _)
-    | CLesser_than      (CInt _, Term (x,None))
-    | CLesser_or_equal  (Term (x,None), CInt _)
-    | CLesser_or_equal  (CInt _, Term (x,None))
-    | CGreater_than     (Term (x,None), CInt _)
-    | CGreater_than     (CInt _, Term (x,None))
-    | CGreater_or_equal (CInt _, Term (x,None))
-    | CGreater_or_equal (Term (x,None), CInt _)
-    | CEqual            (Term (x,None), CInt _)
-    | CEqual            (CInt _, Term (x,None))
-    | CNot_equal        (Term (x,None), CInt _)
-    | CNot_equal        (CInt _, Term (x,None)) -> add_var x "Int"
-    | CAdd              (Term (x,None), CFloat _)
-    | CAdd              (CFloat _, Term (x,None))
-    | CSub              (Term (x,None), CFloat _)
-    | CSub              (CFloat _, Term (x,None))
-    | CMul              (Term (x,None), CFloat _)
-    | CMul              (CFloat _, Term (x,None))
-    | CDiv              (Term (x,None), CFloat _)
-    | CDiv              (CFloat _, Term (x,None))
-    | CLesser_than      (Term (x,None), CFloat _)
-    | CLesser_than      (CFloat _, Term (x,None))
-    | CLesser_or_equal  (Term (x,None), CFloat _)
-    | CLesser_or_equal  (CFloat _, Term (x,None))
-    | CGreater_than     (Term (x,None), CFloat _)
-    | CGreater_than     (CFloat _, Term (x,None))
-    | CGreater_or_equal (Term (x,None), CFloat _)
-    | CGreater_or_equal (CFloat _, Term (x,None))
-    | CEqual            (Term (x,None), CFloat _)
-    | CEqual            (CFloat _, Term (x,None))
-    | CNot_equal        (Term (x,None), CFloat _)
-    | CNot_equal        (CFloat _, Term (x,None)) -> add_var x "Real"
-    | CAdd              (Term (x,None), Term (y,None))
-    | CSub              (Term (x,None), Term (y,None))
-    | CMul              (Term (x,None), Term (y,None))
-    | CDiv              (Term (x,None), Term (y,None))
-    | CLesser_than      (Term (x,None), Term (y,None))
-    | CLesser_or_equal  (Term (x,None), Term (y,None))
-    | CGreater_than     (Term (x,None), Term (y,None))
-    | CGreater_or_equal (Term (x,None), Term (y,None))
-    | CEqual            (Term (x,None), Term (y,None))
-    | CNot_equal        (Term (x,None), Term (y,None)) ->
+    | Add              (Term (x,None), Int _)
+    | Add              (Int _, Term (x,None))
+    | Sub              (Term (x,None), Int _)
+    | Sub              (Int _, Term (x,None))
+    | Mul              (Term (x,None), Int _)
+    | Mul              (Int _, Term (x,None))
+    | Div              (Term (x,None), Int _)
+    | Div              (Int _, Term (x,None))
+    | Lesser_than      (Term (x,None), Int _)
+    | Lesser_than      (Int _, Term (x,None))
+    | Lesser_or_equal  (Term (x,None), Int _)
+    | Lesser_or_equal  (Int _, Term (x,None))
+    | Greater_than     (Term (x,None), Int _)
+    | Greater_than     (Int _, Term (x,None))
+    | Greater_or_equal (Int _, Term (x,None))
+    | Greater_or_equal (Term (x,None), Int _)
+    | Equal            (Term (x,None), Int _)
+    | Equal            (Int _, Term (x,None))
+    | Not_equal        (Term (x,None), Int _)
+    | Not_equal        (Int _, Term (x,None)) -> add_var x "Int"
+    | Add              (Term (x,None), Float _)
+    | Add              (Float _, Term (x,None))
+    | Sub              (Term (x,None), Float _)
+    | Sub              (Float _, Term (x,None))
+    | Mul              (Term (x,None), Float _)
+    | Mul              (Float _, Term (x,None))
+    | Div              (Term (x,None), Float _)
+    | Div              (Float _, Term (x,None))
+    | Lesser_than      (Term (x,None), Float _)
+    | Lesser_than      (Float _, Term (x,None))
+    | Lesser_or_equal  (Term (x,None), Float _)
+    | Lesser_or_equal  (Float _, Term (x,None))
+    | Greater_than     (Term (x,None), Float _)
+    | Greater_than     (Float _, Term (x,None))
+    | Greater_or_equal (Term (x,None), Float _)
+    | Greater_or_equal (Float _, Term (x,None))
+    | Equal            (Term (x,None), Float _)
+    | Equal            (Float _, Term (x,None))
+    | Not_equal        (Term (x,None), Float _)
+    | Not_equal        (Float _, Term (x,None)) -> add_var x "Real"
+    | Add              (Term (x,None), Term (y,None))
+    | Sub              (Term (x,None), Term (y,None))
+    | Mul              (Term (x,None), Term (y,None))
+    | Div              (Term (x,None), Term (y,None))
+    | Lesser_than      (Term (x,None), Term (y,None))
+    | Lesser_or_equal  (Term (x,None), Term (y,None))
+    | Greater_than     (Term (x,None), Term (y,None))
+    | Greater_or_equal (Term (x,None), Term (y,None))
+    | Equal            (Term (x,None), Term (y,None))
+    | Not_equal        (Term (x,None), Term (y,None)) ->
         begin
           try
             let x_type = Hashtbl.find vtbl x in
@@ -122,135 +122,135 @@ let to_smt2 logic formula =
               add_var x typ;
               add_var y typ
         end
-    | CNot x -> gen_var typ x
-    | CAnd     (x,y)
-    | COr      (x,y)
-    | CXor     (x,y)
-    | CImplies (x,y)
-    | CEquiv   (x,y) -> gen_var "Bool" x; gen_var "Bool" y
-    | CAdd              (x, CInt _)
-    | CAdd              (CInt _, x)
-    | CSub              (x, CInt _)
-    | CSub              (CInt _, x)
-    | CMul              (x, CInt _)
-    | CMul              (CInt _, x)
-    | CDiv              (x, CInt _)
-    | CDiv              (CInt _, x)
-    | CEqual            (x, CInt _)
-    | CEqual            (CInt _, x)
-    | CNot_equal        (x, CInt _)
-    | CNot_equal        (CInt _, x)
-    | CLesser_than      (x, CInt _)
-    | CLesser_than      (CInt _, x)
-    | CLesser_or_equal  (x, CInt _)
-    | CLesser_or_equal  (CInt _, x)
-    | CGreater_than     (x, CInt _)
-    | CGreater_than     (CInt _, x)
-    | CGreater_or_equal (x, CInt _)
-    | CGreater_or_equal (CInt _, x)->
+    | Not x -> gen_var typ x
+    | And     (x,y)
+    | Or      (x,y)
+    | Xor     (x,y)
+    | Implies (x,y)
+    | Equiv   (x,y) -> gen_var "Bool" x; gen_var "Bool" y
+    | Add              (x, Int _)
+    | Add              (Int _, x)
+    | Sub              (x, Int _)
+    | Sub              (Int _, x)
+    | Mul              (x, Int _)
+    | Mul              (Int _, x)
+    | Div              (x, Int _)
+    | Div              (Int _, x)
+    | Equal            (x, Int _)
+    | Equal            (Int _, x)
+    | Not_equal        (x, Int _)
+    | Not_equal        (Int _, x)
+    | Lesser_than      (x, Int _)
+    | Lesser_than      (Int _, x)
+    | Lesser_or_equal  (x, Int _)
+    | Lesser_or_equal  (Int _, x)
+    | Greater_than     (x, Int _)
+    | Greater_than     (Int _, x)
+    | Greater_or_equal (x, Int _)
+    | Greater_or_equal (Int _, x)->
         let rec go = function
           | Term (x,None) -> add_var x "Int"
-          | CAdd (x,y)
-          | CSub (x,y)
-          | CMul (x,y)
-          | CDiv (x,y) -> go x; go y
+          | Add (x,y)
+          | Sub (x,y)
+          | Mul (x,y)
+          | Div (x,y) -> go x; go y
           | _ -> failwith "not a term exp"
         in
         if term_expr x then go x else ()
-    | CAdd              (x, CFloat _)
-    | CAdd              (CFloat _, x)
-    | CSub              (x, CFloat _)
-    | CSub              (CFloat _, x)
-    | CMul              (x, CFloat _)
-    | CMul              (CFloat _, x)
-    | CDiv              (x, CFloat _)
-    | CDiv              (CFloat _, x)
-    | CEqual            (x, CFloat _)
-    | CEqual            (CFloat _, x)
-    | CNot_equal        (x, CFloat _)
-    | CNot_equal        (CFloat _, x)
-    | CLesser_than      (x, CFloat _)
-    | CLesser_than      (CFloat _, x)
-    | CLesser_or_equal  (x, CFloat _)
-    | CLesser_or_equal  (CFloat _, x)
-    | CGreater_than     (x, CFloat _)
-    | CGreater_than     (CFloat _, x)
-    | CGreater_or_equal (x, CFloat _)
-    | CGreater_or_equal (CFloat _, x) ->
+    | Add              (x, Float _)
+    | Add              (Float _, x)
+    | Sub              (x, Float _)
+    | Sub              (Float _, x)
+    | Mul              (x, Float _)
+    | Mul              (Float _, x)
+    | Div              (x, Float _)
+    | Div              (Float _, x)
+    | Equal            (x, Float _)
+    | Equal            (Float _, x)
+    | Not_equal        (x, Float _)
+    | Not_equal        (Float _, x)
+    | Lesser_than      (x, Float _)
+    | Lesser_than      (Float _, x)
+    | Lesser_or_equal  (x, Float _)
+    | Lesser_or_equal  (Float _, x)
+    | Greater_than     (x, Float _)
+    | Greater_than     (Float _, x)
+    | Greater_or_equal (x, Float _)
+    | Greater_or_equal (Float _, x) ->
         let rec go = function
           | Term (x,None) -> add_var x "Real"
-          | CAdd (x,y)
-          | CSub (x,y)
-          | CMul (x,y)
-          | CDiv (x,y) -> go x; go y
+          | Add (x,y)
+          | Sub (x,y)
+          | Mul (x,y)
+          | Div (x,y) -> go x; go y
           | _ -> failwith "not a term exp"
         in
         if term_expr x then go x else ()
-    | CAdd              (x, y)
-    | CSub              (x, y)
-    | CMul              (x, y)
-    | CDiv              (x, y)
-    | CEqual            (x, y)
-    | CNot_equal        (x, y)
-    | CLesser_than      (x, y)
-    | CLesser_or_equal  (x, y)
-    | CGreater_than     (x, y)
-    | CGreater_or_equal (x, y) -> gen_var typ x; gen_var typ y
+    | Add              (x, y)
+    | Sub              (x, y)
+    | Mul              (x, y)
+    | Div              (x, y)
+    | Equal            (x, y)
+    | Not_equal        (x, y)
+    | Lesser_than      (x, y)
+    | Lesser_or_equal  (x, y)
+    | Greater_than     (x, y)
+    | Greater_or_equal (x, y) -> gen_var typ x; gen_var typ y
     | _ -> ()
   in
 
   let rec parse = function
-    | CEqual            (x, CInt y) -> gen_var "Int" x(*; CEqual (x, CInt y)*)
-    | CEqual            (CInt x, y) -> gen_var "Int" y(*; CEqual (CInt x, y)*)
-    | CNot_equal        (x, CInt y) -> gen_var "Int" x(*; CNot_equal (x, CInt
+    | Equal            (x, Int y) -> gen_var "Int" x(*; Equal (x, Int y)*)
+    | Equal            (Int x, y) -> gen_var "Int" y(*; Equal (Int x, y)*)
+    | Not_equal        (x, Int y) -> gen_var "Int" x(*; Not_equal (x, Int
     y)*)
-    | CNot_equal        (CInt x, y) -> gen_var "Int" y(*; CNot_equal (CInt x,
+    | Not_equal        (Int x, y) -> gen_var "Int" y(*; Not_equal (Int x,
     y)*)
-    | CLesser_than      (x, CInt y) -> gen_var "Int" x(*; CLesser_than (x, CInt
+    | Lesser_than      (x, Int y) -> gen_var "Int" x(*; Lesser_than (x, Int
     y)*)
-    | CLesser_than      (CInt x, y) -> gen_var "Int" y(*; CLesser_than (CInt x,
+    | Lesser_than      (Int x, y) -> gen_var "Int" y(*; Lesser_than (Int x,
     y)*)
-    | CLesser_or_equal  (x, CInt y) -> gen_var "Int" x(*; CLesser_or_equal (x,
-    CInt y)*)
-    | CLesser_or_equal  (CInt x, y) -> gen_var "Int" y(*; CLesser_or_equal (CInt
+    | Lesser_or_equal  (x, Int y) -> gen_var "Int" x(*; Lesser_or_equal (x,
+    Int y)*)
+    | Lesser_or_equal  (Int x, y) -> gen_var "Int" y(*; Lesser_or_equal (Int
     x, y)*)
-    | CGreater_than     (x, CInt y) -> gen_var "Int" x(*; CGreater_than (x, CInt
+    | Greater_than     (x, Int y) -> gen_var "Int" x(*; Greater_than (x, Int
     y)*)
-    | CGreater_than     (CInt x, y) -> gen_var "Int" y(*; CGreater_than (CInt x,
+    | Greater_than     (Int x, y) -> gen_var "Int" y(*; Greater_than (Int x,
     y)*)
-    | CGreater_or_equal (x, CInt y) -> gen_var "Int" x(*; CGreater_or_equal (x,
-    CInt y)*)
-    | CGreater_or_equal (CInt x, y) -> gen_var "Int" y(*; CGreater_or_equal
-    (CInt x, y)*)
-    | CEqual            (x, CFloat y) -> gen_var "Real" x(*; CEqual (x, CFloat
+    | Greater_or_equal (x, Int y) -> gen_var "Int" x(*; Greater_or_equal (x,
+    Int y)*)
+    | Greater_or_equal (Int x, y) -> gen_var "Int" y(*; Greater_or_equal
+    (Int x, y)*)
+    | Equal            (x, Float y) -> gen_var "Real" x(*; Equal (x, Float
     y)*)
-    | CEqual            (CFloat x, y) -> gen_var "Real" y(*; CEqual (CFloat x,
+    | Equal            (Float x, y) -> gen_var "Real" y(*; Equal (Float x,
     y)*)
-    | CNot_equal        (x, CFloat y) -> gen_var "Real" x(*; CNot_equal (x,
-    CFloat y)*)
-    | CNot_equal        (CFloat x, y) -> gen_var "Real" y(*; CNot_equal (CFloat
+    | Not_equal        (x, Float y) -> gen_var "Real" x(*; Not_equal (x,
+    Float y)*)
+    | Not_equal        (Float x, y) -> gen_var "Real" y(*; Not_equal (Float
     x, y)*)
-    | CLesser_than      (x, CFloat y) -> gen_var "Real" x(*; CLesser_than (x,
-    CFloat y)*)
-    | CLesser_than      (CFloat x, y) -> gen_var "Real" y(*; CLesser_than
-    (CFloat x, y)*)
-    | CLesser_or_equal  (x, CFloat y) -> gen_var "Real" x(*; CLesser_or_equal
-    (x, CFloat y)*)
-    | CLesser_or_equal  (CFloat x, y) -> gen_var "Real" y(*; CLesser_or_equal
-    (CFloat x, y)*)
-    | CGreater_than     (x, CFloat y) -> gen_var "Real" x(*; CGreater_than (x,
-    CFloat y)*)
-    | CGreater_than     (CFloat x, y) -> gen_var "Real" y(*; CGreater_than
-    (CFloat x, y)*)
-    | CGreater_or_equal (x, CFloat y) -> gen_var "Real" x(*; CGreater_or_equal
-    (x, CFloat y)*)
-    | CGreater_or_equal (CFloat x, y) -> gen_var "Real" y(*; CGreater_or_equal
-    (CFloat x, y)*)
-    | CAnd     (x, y) -> gen_var "Bool" x; gen_var "Bool" y(*; CAnd (x, y)*)
-    | COr      (x, y) -> gen_var "Bool" x; gen_var "Bool" y(*; COr  (x, y)*)
-    | CXor     (x, y) -> gen_var "Bool" x; gen_var "Bool" y(*; CXor (x, y)*)
-    | CImplies (x, y) -> gen_var "Bool" x; gen_var "Bool" y(*; CImplies (x, y)*)
-    | CEquiv   (x, y) -> gen_var "Bool" x; gen_var "Bool" y(*; CEquiv (x, y)*)
+    | Lesser_than      (x, Float y) -> gen_var "Real" x(*; Lesser_than (x,
+    Float y)*)
+    | Lesser_than      (Float x, y) -> gen_var "Real" y(*; Lesser_than
+    (Float x, y)*)
+    | Lesser_or_equal  (x, Float y) -> gen_var "Real" x(*; Lesser_or_equal
+    (x, Float y)*)
+    | Lesser_or_equal  (Float x, y) -> gen_var "Real" y(*; Lesser_or_equal
+    (Float x, y)*)
+    | Greater_than     (x, Float y) -> gen_var "Real" x(*; Greater_than (x,
+    Float y)*)
+    | Greater_than     (Float x, y) -> gen_var "Real" y(*; Greater_than
+    (Float x, y)*)
+    | Greater_or_equal (x, Float y) -> gen_var "Real" x(*; Greater_or_equal
+    (x, Float y)*)
+    | Greater_or_equal (Float x, y) -> gen_var "Real" y(*; Greater_or_equal
+    (Float x, y)*)
+    | And     (x, y) -> gen_var "Bool" x; gen_var "Bool" y(*; And (x, y)*)
+    | Or      (x, y) -> gen_var "Bool" x; gen_var "Bool" y(*; Or  (x, y)*)
+    | Xor     (x, y) -> gen_var "Bool" x; gen_var "Bool" y(*; Xor (x, y)*)
+    | Implies (x, y) -> gen_var "Bool" x; gen_var "Bool" y(*; Implies (x, y)*)
+    | Equiv   (x, y) -> gen_var "Bool" x; gen_var "Bool" y(*; Equiv (x, y)*)
     | _ -> failwith "parse error"
   in
 
@@ -258,36 +258,36 @@ let to_smt2 logic formula =
     | Top                        -> "true"
     | Bottom                     -> "false"
     | Term              (x,None) -> sanitize_var x
-    | CInt x ->
+    | Int x ->
         if x < 0 then
           "(- " ^ string_of_int (-x) ^ ")"
         else
           string_of_int   x
-    | CFloat x ->
+    | Float x ->
         let x'  = string_of_float x in
         let x'' = if x'.[String.length x' - 1] = '.' then x' ^ "0" else x' in
         if x''.[0] = '-' then
           "(- " ^ String.sub x'' 1 (String.length x'' - 1) ^ ")"
         else
           x''
-    | CNot              x        -> decl_un_op  "not" (write x)
-    | CAnd              (x,y)    -> decl_bin_op "and" (write x) (write y)
-    | COr               (x,y)    -> decl_bin_op "or"  (write x) (write y)
-    | CXor              (x,y)    -> decl_bin_op "xor" (write x) (write y)
-    | CImplies          (x,y)    -> decl_bin_op "=>" (write x) (write y)
-    | CEquiv            (x,y)    -> write (CAnd (CImplies (x,y), CImplies (y,x)))
-    | CNeg              (CInt x) -> "(- " ^ string_of_int (-x) ^ ")"
-    | CNeg              (CFloat x) -> "(- " ^ string_of_float (-.x) ^ ")"
-    | CAdd              (x,y)    -> decl_bin_op "+" (write x) (write y)
-    | CSub              (x,y)    -> decl_bin_op "-" (write x) (write y)
-    | CMul              (x,y)    -> decl_bin_op "*" (write x) (write y)
-    | CDiv              (x,y)    -> decl_bin_op "/" (write x) (write y)
-    | CEqual            (x,y)    -> decl_bin_op "=" (write x) (write y)
-    | CNot_equal        (x,y)    -> write (CNot (CEqual (x,y)))
-    | CLesser_than      (x,y)    -> decl_bin_op "<" (write x) (write y)
-    | CLesser_or_equal  (x,y)    -> decl_bin_op "<=" (write x) (write y)
-    | CGreater_than     (x,y)    -> decl_bin_op ">" (write x) (write y)
-    | CGreater_or_equal (x,y)    -> decl_bin_op ">=" (write x) (write y)
+    | Not              x        -> decl_un_op  "not" (write x)
+    | And              (x,y)    -> decl_bin_op "and" (write x) (write y)
+    | Or               (x,y)    -> decl_bin_op "or"  (write x) (write y)
+    | Xor              (x,y)    -> decl_bin_op "xor" (write x) (write y)
+    | Implies          (x,y)    -> decl_bin_op "=>" (write x) (write y)
+    | Equiv            (x,y)    -> write (And (Implies (x,y), Implies (y,x)))
+    | Neg              (Int x) -> "(- " ^ string_of_int (-x) ^ ")"
+    | Neg              (Float x) -> "(- " ^ string_of_float (-.x) ^ ")"
+    | Add              (x,y)    -> decl_bin_op "+" (write x) (write y)
+    | Sub              (x,y)    -> decl_bin_op "-" (write x) (write y)
+    | Mul              (x,y)    -> decl_bin_op "*" (write x) (write y)
+    | Div              (x,y)    -> decl_bin_op "/" (write x) (write y)
+    | Equal            (x,y)    -> decl_bin_op "=" (write x) (write y)
+    | Not_equal        (x,y)    -> write (Not (Equal (x,y)))
+    | Lesser_than      (x,y)    -> decl_bin_op "<" (write x) (write y)
+    | Lesser_or_equal  (x,y)    -> decl_bin_op "<=" (write x) (write y)
+    | Greater_than     (x,y)    -> decl_bin_op ">" (write x) (write y)
+    | Greater_or_equal (x,y)    -> decl_bin_op ">=" (write x) (write y)
     | _ -> failwith "error smt write"
   in
 

--- a/touist-translator/src/syntax.ml
+++ b/touist-translator/src/syntax.ml
@@ -34,7 +34,7 @@ module GenSet = struct
 end
 
 type prog =
-  | Prog of affect list option * clause list
+  | Prog of affect list option * exp list
 and affect =
   | Affect of var * exp
 and var = string * exp list option
@@ -45,7 +45,6 @@ and exp =
   | Var              of var
   | Set              of GenSet.t
   | Set_decl         of exp list
-  | Clause           of clause
   | Neg              of exp
   | Add              of exp * exp
   | Sub              of exp * exp
@@ -55,6 +54,8 @@ and exp =
   | Sqrt             of exp
   | To_int           of exp
   | To_float         of exp
+  | Top
+  | Bottom
   | Not              of exp
   | And              of exp * exp
   | Or               of exp * exp
@@ -76,33 +77,9 @@ and exp =
   | Subset           of exp * exp
   | In               of exp * exp
   | If               of exp * exp * exp
-and clause =
-  | CInt              of int
-  | CFloat            of float
-  | CNeg              of clause
-  | CAdd              of clause * clause
-  | CSub              of clause * clause
-  | CMul              of clause * clause
-  | CDiv              of clause * clause
-  | CEqual            of clause * clause
-  | CNot_equal        of clause * clause
-  | CLesser_than      of clause * clause
-  | CLesser_or_equal  of clause * clause
-  | CGreater_than     of clause * clause
-  | CGreater_or_equal of clause * clause
-  | Top
-  | Bottom
   | Term     of var
-  | CVar     of var
-  | CNot     of clause
-  | CAnd     of clause * clause
-  | COr      of clause * clause
-  | CXor     of clause * clause
-  | CImplies of clause * clause
-  | CEquiv   of clause * clause
   | Exact    of exp * exp
   | Atleast  of exp * exp
   | Atmost   of exp * exp
-  | Bigand   of string list * exp list * exp option * clause
-  | Bigor    of string list * exp list * exp option * clause
-  | CIf      of exp * clause * clause
+  | Bigand   of string list * exp list * exp option * exp
+  | Bigor    of string list * exp list * exp option * exp

--- a/touist-translator/src/touistc.ml
+++ b/touist-translator/src/touistc.ml
@@ -117,8 +117,8 @@ let print_position outx lexbuf =
  *
  * [ast] means it is of type Syntax.prog,
  * i.e. the "root" type in lexer.mll
-*)
-let evaluate (ast:Syntax.prog) : Syntax.clause =
+ *)
+let evaluate (ast:Syntax.prog) : Syntax.exp =
   try Eval.eval ast [] with
   | Eval.UnknownVar msg ->
     Printf.fprintf stderr "the variable %s has not been declared\n" msg;

--- a/touist-translator/src/touistc.ml
+++ b/touist-translator/src/touistc.ml
@@ -189,7 +189,7 @@ let translateToSATDIMACS (infile:in_channel) (outfile:out_channel) (tablefile:ou
   and buffer = ref ErrorReporting.Zero in
   let ast = invoke_parser text (lexer buffer) buffer in
   let exp = evaluate ast in
-  if !debug_formula_expansion then print_string (string_of_clause exp)
+  if !debug_formula_expansion then print_string (string_of_exp exp)
   else
     let c,t = Cnf.transform_to_cnf exp !debug_cnf |> Dimacs.to_dimacs in
     Printf.fprintf outfile "%s" c;


### PR DESCRIPTION
This refactoring was necessary because everything was duplicated in `pprint.ml` which was REALLY bugging me for creating a latex printer built into touistc.