### PR TITLE
touist won't crash anymore when temp.touistl cannot be created

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,6 @@
+v2.0.1
+  - gui:
+    - fixed crash when touist.jar was opened from inside the zip archive
 v2.0.0
   - touistc:
     - simplified 'begin sets end sets begin formula end formula'; syntax is

--- a/touist-gui/src/gui/editionView/ParentEditionPanel.java
+++ b/touist-gui/src/gui/editionView/ParentEditionPanel.java
@@ -469,10 +469,8 @@ public class ParentEditionPanel extends AbstractComponentPanel {
         try {
             getFrame().getTextInEditor().saveToFile(bigAndFilePath);
         } catch (IOException ex) {
-            ex.printStackTrace();
-            errorMessage = "Couldn't create file '" + bigAndFilePath + "'";
+            errorMessage = "Couldn't create file '" + bigAndFilePath + "':\n"+ex.getMessage();
             showErrorMessage(errorMessage, getFrame().getLang().getWord(Lang.ERROR_TRADUCTION));
-            System.exit(0);
             return State.EDITION;
         }
         


### PR DESCRIPTION
Note that it often happens when people launch touist.jar
from the zip archive!

Fixes #210