### PR TITLE
fix ctrl+left and right arrow for moving word-by-word on Windows

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,7 @@
+v2.1.3
+  - gui:
+    - ctrl+left and ctrl+right are now working properly for moving
+      word by word in the text editor on Windows
 v2.1.2
   - touistc:
     - abs() is now supported (absolute value)

--- a/touist-gui/src/gui/editionView/editor/Editor.java
+++ b/touist-gui/src/gui/editionView/editor/Editor.java
@@ -174,6 +174,11 @@ public class Editor extends RSyntaxTextArea  {
         snipetsBegin = new ArrayList<Integer>();
         snipetsEnd = new ArrayList<Integer>();
         
+        // Note: I disabled ctrl+left and ctrl+right for moving through snippet tokens
+        // because it was disabling the possibilty of moving through the text word by word on
+        // Windows.
+        
+        /*
         this.getDocument().addDocumentListener(new SnippetListener());
         String rightKeyStrokeAndKey = "control RIGHT";
         KeyStroke rightKeyStroke = KeyStroke.getKeyStroke(rightKeyStrokeAndKey);
@@ -183,6 +188,7 @@ public class Editor extends RSyntaxTextArea  {
         KeyStroke leftKeyStroke = KeyStroke.getKeyStroke(leftKeyStrokeAndKey);
         this.getInputMap().put(leftKeyStroke, leftKeyStrokeAndKey);
         this.getActionMap().put(leftKeyStrokeAndKey, new SnippetLeftAction(this));
+        */
         
 
     }


### PR DESCRIPTION
fixes #225