### PR TITLE
Add timings

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -2,7 +2,6 @@ v3.5.2
   - Language:
     - added list comprehensions (also named 'set builder notation'). Really
       useful for generating sets! Example: [p($i,$j) for $i,$j in [1..2],[a,b]].
-v3.5.2
   - Command-line
     - it is now possible to display elapsed time (translation time and solve
       time) in --solve and --solver modes. To enable it, use -v/--verbose.

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -2,6 +2,10 @@ v3.5.2
   - Language:
     - added list comprehensions (also named 'set builder notation'). Really
       useful for generating sets! Example: [p($i,$j) for $i,$j in [1..2],[a,b]].
+v3.5.2
+  - Command-line
+    - it is now possible to display elapsed time (translation time and solve
+      time) in --solve and --solver modes. To enable it, use -v/--verbose.
 v3.5.1 (2018-01-07)
   - GUI (fixes):
     - fixed wrong line numbers displayed in error messages in QBF and SMT modes

--- a/touist
+++ b/touist
@@ -1,0 +1,2 @@
+#! /usr/bin/env bash
+jbuilder build @install && jbuilder exec touist -- "$@"


### PR DESCRIPTION
When using `-v` (verbose), it displays:
```
== translation time: 4.23102 sec
== solve time: 1.19282 sec
```
### Availability:

|             | `--sat` |     `--smt`     | `--qbf`  |
|-------------|:-------:|:---------------:|:--------:|
| `translate` | OK      | (useless?)      | OK       |
| `--solve`   | OK      | OK              | **todo** |
| `--solver=` | OK      | (not available) | OK       |