### PR TITLE
Rewrite `exact` to get exponentially less number of clauses

### DIFF
--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -5,3 +5,6 @@
 image: touist/touist-gitpod:latest
 tasks:
   - command: dune build && dune install
+vscode:
+  extensions:
+    - freebroccolo.reasonml@1.0.38:8z272/hdnsThUvPLXoPqHA==

--- a/src/lib/cnf.mli
+++ b/src/lib/cnf.mli
@@ -123,10 +123,3 @@ val print_table :
     v} *)
 val print_clauses :
   out_channel -> ?prefix:string -> ('a -> string) -> 'a list list -> unit
-
-(** {2 Other functions} *)
-
-(** [is_dummy name] tells (using the [name] of a litteral) is a 'dummy' literal
-    that was introduced during cnf conversion; these literals are identified
-    by their prefix '&'. *)
-(*val is_dummy : string -> bool*)

--- a/src/lib/cnf.mli
+++ b/src/lib/cnf.mli
@@ -129,4 +129,4 @@ val print_clauses :
 (** [is_dummy name] tells (using the [name] of a litteral) is a 'dummy' literal
     that was introduced during cnf conversion; these literals are identified
     by their prefix '&'. *)
-val is_dummy : string -> bool
+(*val is_dummy : string -> bool*)

--- a/src/lib/dummy.ml
+++ b/src/lib/dummy.ml
@@ -1,0 +1,5 @@
+let dummy_term_count = ref 0
+let fresh_dummy () =
+  incr dummy_term_count; Types.Ast.Prop ("&" ^ (string_of_int !dummy_term_count))
+
+let is_dummy (name:string) : bool = (name).[0] = '&'

--- a/src/lib/dummy.ml
+++ b/src/lib/dummy.ml
@@ -1,5 +1,8 @@
 let dummy_term_count = ref 0
+let uuid () =
+  incr dummy_term_count; !dummy_term_count
+
 let fresh_dummy () =
-  incr dummy_term_count; Types.Ast.Prop ("&" ^ (string_of_int !dummy_term_count))
+  Types.Ast.Prop ("&" ^ (string_of_int (uuid ())))
 
 let is_dummy (name:string) : bool = (name).[0] = '&'

--- a/src/lib/dummy.mli
+++ b/src/lib/dummy.mli
@@ -1,0 +1,11 @@
+(** [fresh_dummy] generates a 'dummy' proposition named ["&i"] with [i] being a
+    self-incrementing index.
+    This function allows to speed up and simplify the translation of some
+    forms of Or.
+    NOTE: OCaml's functions can't have 0 param: we use the unit [()]. *)
+val fresh_dummy : unit -> Types.Ast.t
+
+(** [is_dummy name] tells (using the [name] of a litteral) is a 'dummy' literal
+    that was introduced during cnf conversion; these literals are identified
+    by their prefix '&'. *)
+val is_dummy : string -> bool

--- a/src/lib/dummy.mli
+++ b/src/lib/dummy.mli
@@ -5,6 +5,9 @@
     NOTE: OCaml's functions can't have 0 param: we use the unit [()]. *)
 val fresh_dummy : unit -> Types.Ast.t
 
+(** [uuid] generates an uuid that using a self-incrementing index.*)
+val uuid : unit -> int
+
 (** [is_dummy name] tells (using the [name] of a litteral) is a 'dummy' literal
     that was introduced during cnf conversion; these literals are identified
     by their prefix '&'. *)

--- a/src/lib/satSolve.ml
+++ b/src/lib/satSolve.ml
@@ -121,7 +121,7 @@ let solve_clauses
       || not (Minisat.Raw.solve solver [||])
       then models
       else
-        let model = get_model solver table Cnf.is_dummy (* is_dummy removes &1 lits *)
+        let model = get_model solver table Dummy.is_dummy (* is_dummy removes &1 lits *)
         and has_next_model = counter_current_model solver table in
         let is_duplicate = Hashtbl.mem models_hash model in
         match is_duplicate,has_next_model with

--- a/test/test.ml
+++ b/test/test.ml
@@ -16,7 +16,7 @@ let is_msg typ during loc_str msg =
         && d == during -> true
   | _ -> false
 
-let test_raise (parse:(string->unit)) (during:Touist.Err.during) typ nth_msg (loc_expected:string) text =
+let test_raise (parse:(string->unit)) (during:Touist.Err.during) typ _ (loc_expected:string) text =
   try parse text;
     if typ == Touist.Err.Error then
       OUnit2.assert_failure ("this test didn't raise an error at location '"^loc_expected^"' as expected")
@@ -51,7 +51,7 @@ let test_qbf text _ =
 
 let test_sat_raise ?(during=Touist.Err.Eval) ?(typ=Touist.Err.Error) ?(nth=0) loc text _ = test_raise sat during typ nth loc text
 let test_smt_raise ?(during=Touist.Err.Eval) ?(typ=Touist.Err.Error) ?(nth=0) ?(logic="QF_IDL") loc text _ = test_raise (smt logic) during typ nth loc text
-let test_qbf_raise ?(during=Touist.Err.Eval) ?(typ=Touist.Err.Error) ?(nth=0) ?(logic="QF_IDL") loc text _ = test_raise qbf during typ nth loc text
+let test_qbf_raise ?(during=Touist.Err.Eval) ?(typ=Touist.Err.Error) ?(nth=0) loc text _ = test_raise qbf during typ nth loc text
 
 let sat_models_are text expected _ =
   OUnit2.assert_equal ~printer:(fun s -> s)
@@ -178,9 +178,8 @@ run_test_tt_main (
   "atleast(0,[]) should be true">::(sat_expands_to "atleast(0,[])" "Top");
   "atleast(5,[]) should be false">::(sat_expands_to "atleast(5,[])" "Bot");
   "normal cases">:::[
-  "exact(0,[a,b]) should return 'not a and not b'">::(sat_expands_to "exact(0,[a,b])" "(not a and not b)");
-  "exact(1,[a,b,c]) should give 3 models">::(sat_models_are "exact(1,[a,b,c])" "0 b 0 a 1 c | 0 b 1 a 0 c | 1 b 0 a 0 c");
-  "exact(3,[a,b,c]) should give 1 model">::(sat_models_are "exact(3,[a,b,c])" "1 c 1 b 1 a");
+  "exact(1,[a,b,c]) should give 3 models">::(sat_models_are "exact(1,[a,b,c])" "1 a 0 b 0 c | 0 a 1 b 0 c | 0 a 0 b 1 c");
+  "exact(3,[a,b,c]) should give 1 model">::(sat_models_are "exact(3,[a,b,c])" "1 a 1 c 1 b");
   "'atmost(2,[a,b,c]) a' should give 3 models">::(sat_models_are "atmost(2,[a,b,c]) a" "1 a 0 b 0 c | 1 a 0 b 1 c | 1 a 1 b 0 c");
   "'atmost(2,[a,b,c]) a b' should give 1 model">::(sat_models_are "atmost(2,[a,b,c]) a b" "1 b 1 a 0 c");
   "'atleast(2,[a,b,c])' should give 4 model">::(sat_models_are "atleast(2,[a,b,c])" "1 c 1 b 0 a | 1 c 1 b 1 a | 0 c 1 b 1 a | 1 c 0 b 1 a");


### PR DESCRIPTION
Use the fact that (n k) = (n-1 k-1) + (n-1 k) to introduce literals to reduce exponentially the number of clauses needed to represent n chooses k. 
The definition of the pascal triangle needs to be at the top level so as not to interfere with the rest of the formula.