### PR TITLE
Dune: js_of_ocaml.weak and js_of_ocaml.ppx don't seem to exist anymore?

### DIFF
--- a/src/js/dune
+++ b/src/js/dune
@@ -7,12 +7,13 @@
 
 (executable
  (name touistjs)
- (libraries re re.str touist js_of_ocaml js_of_ocaml-ppx js_of_ocaml.weak
+ (modes js)
+ (libraries re re.str touist js_of_ocaml
    yojson ppx_deriving ppx_deriving_yojson ppx_deriving_yojson.runtime)
  (js_of_ocaml
   (flags :standard +weak.js +nat.js +dynlink.js +toplevel.js))
  (preprocess
-  (pps js_of_ocaml.ppx ppx_deriving_yojson))
+  (pps js_of_ocaml-ppx ppx_deriving_yojson))
  (link_flags :standard -linkall)
  (flags :standard -g))
 


### PR DESCRIPTION
I've used the Dune sample that is visible in https://dune.readthedocs.io/en/stable/jsoo.html:

```dune
(executable
   (name foo)
   (modes js)
   (preprocess (pps js_of_ocaml-ppx)))
```

But it seems like there are still problems while compiling:

```
$ dune build
Entering directory '/Users/mvalais/code/touist'
File "src/lib/satSolve.ml", line 24, characters 11-35:
24 |         if Minisat.Raw.add_clause_a solver a then add_clauses solver next
                ^^^^^^^^^^^^^^^^^^^^^^^^
Error: Unbound module Minisat.Raw
```

## Reproducing this error

First, I followed the instructions in https://github.com/touist/touist/blob/master/INSTALL.md :


```bash
brew install ocaml opamopam init -y --shell-setup
opam install . --deps-only --with-test
```

Voici les versions d'OCaml que j'ai utilisées :

```console
$ opam switch
#  switch   compiler                                            description
$ ocaml --version
The OCaml toplevel, version 4.14.0
```

I then followed the instructions in https://github.com/touist/touist/blob/master/src/js/dune:

```bash
opam install js_of_ocaml js_of_ocaml-ppx js_of_ocaml-compiler yojson ppx_deriving_yojson
```

Then, I tried building `touistjs.bc.js`:

```
cd src/js/
dune build
```
and got the error:

```
Error: Unbound module Minisat.Raw
```

I seems like Minisat.Raw was removed in June 2023: https://github.com/c-cube/ocaml-minisat/commit/d85a450c976c31f58e7c192fcf182895a51f7b7b. Not sure why... That will need fixing to make everything work again.